### PR TITLE
Modifies plugin to ignore dashes as special characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile-plugin-fulltext-filter",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4455,9 +4455,9 @@
       }
     },
     "pg-tsquery": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/pg-tsquery/-/pg-tsquery-6.7.2.tgz",
-      "integrity": "sha512-q50nJtuCaJy5UBUZEp0yWb+fgPU8URBhWR1eury6Hh84gLyLArX/6mRmP0R9qWotVqck6boX6NQnK5hpinVewg=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/pg-tsquery/-/pg-tsquery-8.3.0.tgz",
+      "integrity": "sha512-TzfBArVjA1XP7D71Sgy0DSS/e85IuisZigOk8W3PzYlyr12Z6ieoXX6XxyLuXI06Ir6ZRD2qCTq2Kom0idu9rg=="
     },
     "pg-types": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile-plugin-fulltext-filter",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "description": "Full text searching on tsvector fields for use with postgraphile-plugin-connection-filter",
   "main": "index.js",
   "repository": {
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "graphile-build-pg": "^4.2.0",
-    "pg-tsquery": "^6.4.2",
+    "pg-tsquery": "^8.3.0",
     "postgraphile-plugin-connection-filter": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Modifies the plugin configuration options from https://github.com/caub/pg-tsquery/blob/master/index.js#L63 to not treat `-` as a special character. (essentially took the default regexes and removed `-`)